### PR TITLE
fix(windows): use /await:strict for C++20 coroutines on MSVC

### DIFF
--- a/webview_all_windows/windows/CMakeLists.txt
+++ b/webview_all_windows/windows/CMakeLists.txt
@@ -66,7 +66,7 @@ add_library(${PLUGIN_NAME} SHARED ${PLUGIN_SOURCES})
 add_dependencies(${PLUGIN_NAME} ${DEPS_TARGET_NAME})
 
 if(MSVC)
-  target_compile_options(${PLUGIN_NAME} PRIVATE "/await")
+  target_compile_options(${PLUGIN_NAME} PRIVATE "/await:strict")
 endif()
 
 apply_standard_settings(${PLUGIN_NAME})


### PR DESCRIPTION
## Problem

Windows builds fail with recent Visual Studio / MSVC toolchains when this plugin uses the experimental coroutine flag `/await`.

The `/await` switch is the legacy/experimental coroutine mode and was **removed in MSVC 14.51+** (Visual Studio 2022 17.14+). Projects that target standard C++20 coroutines cannot compile with this flag on recent toolchains.

## Fix

Replace `/await` with `/await:strict` in `webview_all_windows/windows/CMakeLists.txt`:

```cmake
if(MSVC)
  target_compile_options(${PLUGIN_NAME} PRIVATE "/await:strict")
endif()
```

`/await:strict` enables standard-conforming C++20 coroutines and is compatible with current MSVC versions.

The target already declares `target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_20)`, so no other change is needed. No functional behavior is altered.

## Verification

- Plugin builds successfully with Visual Studio / MSVC 14.51+ using `/await:strict`
- No other changes made
